### PR TITLE
fix: Add header for GCC 13

### DIFF
--- a/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
+++ b/submodules/diff-gaussian-rasterization/cuda_rasterizer/rasterizer_impl.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include "rasterizer.h"
 #include <cuda_runtime_api.h>
+#include <cstdint>
 
 namespace CudaRasterizer
 {


### PR DESCRIPTION
The issue is [GCC 13 does not implicitly include cstdint](https://gcc.gnu.org/gcc-13/porting_to.html).

The fix is simply add the header:
```
#include <cstdint>
``` 

Ref: graphdeco-inria/gaussian-splatting#788

PS. I'm trying to install [TRELLIS](https://github.com/microsoft/TRELLIS) using PyTorch 2.5.1 + CUDA 12.4 + GCC 13. TRELLIS' install script is installing your [diff-gaussian-rasterization] as dependency. That's why I'm encountering this issue. Luckily I have fixed the [same issue](https://github.com/ashawkey/diff-gaussian-rasterization/pull/22) before. So I just make the pull request. Thanks for your amazing work!